### PR TITLE
Remove crypto package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "url": "https://www.antuankhanna.com"
   },
   "dependencies": {
-    "crypto": "^0.0.3",
     "request": "2.80.x"
   }
 }


### PR DESCRIPTION
This package has been deprecated
Author message:

This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.

ref: https://www.npmjs.com/package/crypto